### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/aguss787/jedit/compare/v0.1.0...v0.1.1) - 2025-05-10
+
+### Fixed
+
+- move to botom index out of bound
+
+### Other
+
+- fix missing crates.io release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jedit"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "byte-unit",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "jedit"
 description = "Command-line tool to view and edit large JSON file"
 repository = "https://github.com/aguss787/jedit"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT"
 


### PR DESCRIPTION



## 🤖 New release

* `jedit`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/aguss787/jedit/compare/v0.1.0...v0.1.1) - 2025-05-10

### Fixed

- move to botom index out of bound

### Other

- fix missing crates.io release
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).