### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/aguss787/jedit/compare/v0.1.2...v0.1.3) - 2025-05-12
+
+### Added
+
+- better tree
+- delete key
+
+### Fixed
+
+- remove unstabilized let chain
+
+### Other
+
+- remove unused lifetime
+- *(README)* remove delete key todo from readme
+- *(README)* add step to install from crates.io
+- *(README)* add edit key binding
+
 ## [0.1.2](https://github.com/aguss787/jedit/compare/v0.1.1...v0.1.2) - 2025-05-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jedit"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "byte-unit",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "jedit"
 description = "Command-line tool to view and edit large JSON file"
 repository = "https://github.com/aguss787/jedit"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 license = "MIT"
 


### PR DESCRIPTION



## 🤖 New release

* `jedit`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/aguss787/jedit/compare/v0.1.2...v0.1.3) - 2025-05-12

### Added

- better tree
- delete key

### Fixed

- remove unstabilized let chain

### Other

- remove unused lifetime
- *(README)* remove delete key todo from readme
- *(README)* add step to install from crates.io
- *(README)* add edit key binding
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).